### PR TITLE
Issue #18 - Fix incorrect version tag: 0.1.0 should be 0.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ npm run typecheck      # TypeScript strict mode
 
 ## Changelog
 
-### v0.1.0 (in progress)
+### v0.0.1 (in progress)
 
 Phase 1: Foundation — core shell, database, browsing views, and media type system.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "trove",
-  "version": "0.1.0",
+  "version": "0.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "trove",
-      "version": "0.1.0",
+      "version": "0.0.1",
       "dependencies": {
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
@@ -2496,6 +2496,70 @@
       "engines": {
         "node": ">=14.0.0"
       }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.1.0",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1",
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
+      "version": "2.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "0BSD",
+      "optional": true
     },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
       "version": "4.2.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trove",
-  "version": "0.1.0",
+  "version": "0.0.1",
   "description": "A personal media library manager",
   "type": "module",
   "main": "./out/main/index.js",


### PR DESCRIPTION
All done. Here's what was done:

**Issue #18 filed:** [[Fix incorrect version tag: 0.1.0 should be 0.0.1](https://github.com/aellington89/trove/issues/18)](https://github.com/aellington89/trove/issues/18)
- Labels: `bug`, `priority: high`, `size: XS` (created the priority/size label families)
- Linked to: **Trove v1.0.0** project

**Files updated:**
- `package.json` — `0.1.0` → `0.0.1`
- `package-lock.json` — regenerated via `npm install --package-lock-only`
- `README.md` — changelog heading updated to `v0.0.1`