### PR TITLE
Issue #4 - Zustand Store Setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,11 +50,17 @@ src/
     ├── assets/
     │   └── fonts/                 # Syne + DM Sans (local, no CDN)
     └── src/
-        ├── main.tsx               # React entry point
+        ├── main.tsx               # React entry point + store initialization
         ├── App.tsx                # Root component
         ├── app.css                # Tailwind imports, font faces, theme
-        └── lib/
-            └── trove-api.ts       # Typed renderer API wrapper (IPC client)
+        ├── lib/
+        │   └── trove-api.ts       # Typed renderer API wrapper (IPC client)
+        └── stores/
+            ├── index.ts           # Barrel export for all stores + subscriptions
+            ├── items-store.ts     # Items CRUD state + actions (fetches via IPC)
+            ├── media-types-store.ts # Media type list state + lookup helper
+            ├── ui-store.ts        # View, filter, sort, search, sidebar state
+            └── subscriptions.ts   # Cross-store wiring (filter changes → refetch)
 ```
 
 Build output goes to `out/` (Vite bundles) and `dist/` (packaged binaries). Database is stored at `{userData}/library.trove` with a sibling `/covers` directory for cover art.
@@ -118,6 +124,7 @@ npm run test:coverage  # Vitest with coverage
 
 Phase 1: Foundation — core shell, database, browsing views, and media type system.
 
+- **1.4 Zustand Store Setup** (2026-03-27) — Three Zustand stores (items, media types, UI state), cross-store subscriptions with debounced search, devtools middleware, store unit tests
 - **Hotfix** (2026-03-22) — Added `.gitattributes` to normalize line endings, fixing phantom CRLF/LF diffs on Windows (#22)
 - **1.3 Data Access Layer** (2026-03-21) — IPC handlers for CRUD operations, typed renderer API, shared TypeScript interfaces, repository pattern with tests
 - **1.2 SQLite Integration** (2026-03-21) — better-sqlite3, migration system, items/media_types schema, 5 built-in media type seeds, Vitest setup

--- a/src/renderer/src/main.tsx
+++ b/src/renderer/src/main.tsx
@@ -2,6 +2,11 @@ import React from 'react'
 import ReactDOM from 'react-dom/client'
 import App from './App'
 import './app.css'
+import { setupStoreSubscriptions, useMediaTypesStore, useItemsStore } from './stores'
+
+setupStoreSubscriptions()
+useMediaTypesStore.getState().fetchMediaTypes()
+useItemsStore.getState().fetchItems()
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>

--- a/src/renderer/src/stores/__tests__/items-store.test.ts
+++ b/src/renderer/src/stores/__tests__/items-store.test.ts
@@ -1,0 +1,236 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import type { Item, CreateItemInput, UpdateItemInput } from '../../../../shared/types'
+import { useItemsStore } from '../items-store'
+import { useUIStore } from '../ui-store'
+
+vi.mock('../../lib/trove-api')
+
+import * as troveApi from '../../lib/trove-api'
+
+const mockItem: Item = {
+  id: '01ABC',
+  type: 'books',
+  title: 'The Hobbit',
+  status: 'Owned',
+  rating: 5,
+  cover_path: null,
+  cover_hue: 120,
+  metadata: { author: 'J.R.R. Tolkien' },
+  notes: null,
+  date_added: '2026-01-01T00:00:00.000Z',
+  date_modified: '2026-01-01T00:00:00.000Z',
+}
+
+const mockItem2: Item = {
+  id: '01DEF',
+  type: 'music',
+  title: 'Abbey Road',
+  status: 'Owned',
+  rating: 5,
+  cover_path: null,
+  cover_hue: 200,
+  metadata: { artist: 'The Beatles' },
+  notes: null,
+  date_added: '2026-01-02T00:00:00.000Z',
+  date_modified: '2026-01-02T00:00:00.000Z',
+}
+
+describe('Items Store', () => {
+  beforeEach(() => {
+    useItemsStore.getState()._reset()
+    useUIStore.getState()._reset()
+    vi.clearAllMocks()
+  })
+
+  describe('initial state', () => {
+    it('has correct defaults', () => {
+      const state = useItemsStore.getState()
+      expect(state.items).toEqual([])
+      expect(state.total).toBe(0)
+      expect(state.selectedItem).toBeNull()
+      expect(state.isLoading).toBe(false)
+      expect(state.error).toBeNull()
+    })
+  })
+
+  describe('fetchItems', () => {
+    it('fetches items with default UI filters', async () => {
+      vi.mocked(troveApi.getItems).mockResolvedValue({ items: [mockItem], total: 1 })
+
+      await useItemsStore.getState().fetchItems()
+
+      expect(troveApi.getItems).toHaveBeenCalledWith({
+        type: undefined,
+        search: undefined,
+        sortBy: 'date_added',
+        sortDirection: 'desc',
+      })
+      const state = useItemsStore.getState()
+      expect(state.items).toEqual([mockItem])
+      expect(state.total).toBe(1)
+      expect(state.isLoading).toBe(false)
+    })
+
+    it('reads filters from UI store', async () => {
+      useUIStore.getState().setActiveTypeFilter('books')
+      useUIStore.getState().setSearchQuery('hobbit')
+      useUIStore.getState().setSortConfig({ field: 'title', direction: 'asc' })
+
+      vi.mocked(troveApi.getItems).mockResolvedValue({ items: [mockItem], total: 1 })
+
+      await useItemsStore.getState().fetchItems()
+
+      expect(troveApi.getItems).toHaveBeenCalledWith({
+        type: 'books',
+        search: 'hobbit',
+        sortBy: 'title',
+        sortDirection: 'asc',
+      })
+    })
+
+    it('sets isLoading during fetch', async () => {
+      let resolvePromise: (value: { items: Item[]; total: number }) => void
+      vi.mocked(troveApi.getItems).mockImplementation(
+        () => new Promise((resolve) => (resolvePromise = resolve)),
+      )
+
+      const promise = useItemsStore.getState().fetchItems()
+      expect(useItemsStore.getState().isLoading).toBe(true)
+
+      resolvePromise!({ items: [], total: 0 })
+      await promise
+      expect(useItemsStore.getState().isLoading).toBe(false)
+    })
+
+    it('handles errors', async () => {
+      vi.mocked(troveApi.getItems).mockRejectedValue(new Error('DB error'))
+
+      await useItemsStore.getState().fetchItems()
+
+      const state = useItemsStore.getState()
+      expect(state.error).toBe('DB error')
+      expect(state.isLoading).toBe(false)
+    })
+  })
+
+  describe('fetchItem', () => {
+    it('sets selectedItem', async () => {
+      vi.mocked(troveApi.getItem).mockResolvedValue(mockItem)
+
+      await useItemsStore.getState().fetchItem('01ABC')
+
+      expect(useItemsStore.getState().selectedItem).toEqual(mockItem)
+    })
+
+    it('handles errors', async () => {
+      vi.mocked(troveApi.getItem).mockRejectedValue(new Error('Not found'))
+
+      await useItemsStore.getState().fetchItem('missing')
+
+      expect(useItemsStore.getState().error).toBe('Not found')
+    })
+  })
+
+  describe('createItem', () => {
+    it('creates an item and refreshes the list', async () => {
+      const input: CreateItemInput = { type: 'books', title: 'New Book' }
+      vi.mocked(troveApi.createItem).mockResolvedValue(mockItem)
+      vi.mocked(troveApi.getItems).mockResolvedValue({ items: [mockItem], total: 1 })
+
+      const result = await useItemsStore.getState().createItem(input)
+
+      expect(troveApi.createItem).toHaveBeenCalledWith(input)
+      expect(result).toEqual(mockItem)
+      expect(troveApi.getItems).toHaveBeenCalled()
+      expect(useItemsStore.getState().items).toEqual([mockItem])
+    })
+  })
+
+  describe('updateItem', () => {
+    it('updates item in-place in the items array', async () => {
+      // Seed the store with items
+      vi.mocked(troveApi.getItems).mockResolvedValue({ items: [mockItem, mockItem2], total: 2 })
+      await useItemsStore.getState().fetchItems()
+
+      const updated = { ...mockItem, title: 'The Hobbit (Revised)' }
+      const input: UpdateItemInput = { title: 'The Hobbit (Revised)' }
+      vi.mocked(troveApi.updateItem).mockResolvedValue(updated)
+
+      const result = await useItemsStore.getState().updateItem('01ABC', input)
+
+      expect(result.title).toBe('The Hobbit (Revised)')
+      expect(useItemsStore.getState().items[0].title).toBe('The Hobbit (Revised)')
+      expect(useItemsStore.getState().items[1]).toEqual(mockItem2)
+    })
+
+    it('updates selectedItem if it matches', async () => {
+      vi.mocked(troveApi.getItem).mockResolvedValue(mockItem)
+      await useItemsStore.getState().fetchItem('01ABC')
+
+      // Also seed items list
+      vi.mocked(troveApi.getItems).mockResolvedValue({ items: [mockItem], total: 1 })
+      await useItemsStore.getState().fetchItems()
+
+      const updated = { ...mockItem, rating: 3 }
+      vi.mocked(troveApi.updateItem).mockResolvedValue(updated)
+
+      await useItemsStore.getState().updateItem('01ABC', { rating: 3 })
+
+      expect(useItemsStore.getState().selectedItem?.rating).toBe(3)
+    })
+
+    it('does not touch selectedItem if ids differ', async () => {
+      vi.mocked(troveApi.getItem).mockResolvedValue(mockItem2)
+      await useItemsStore.getState().fetchItem('01DEF')
+
+      vi.mocked(troveApi.getItems).mockResolvedValue({ items: [mockItem, mockItem2], total: 2 })
+      await useItemsStore.getState().fetchItems()
+
+      const updated = { ...mockItem, rating: 1 }
+      vi.mocked(troveApi.updateItem).mockResolvedValue(updated)
+
+      await useItemsStore.getState().updateItem('01ABC', { rating: 1 })
+
+      expect(useItemsStore.getState().selectedItem).toEqual(mockItem2)
+    })
+  })
+
+  describe('deleteItem', () => {
+    it('removes item from array and decrements total', async () => {
+      vi.mocked(troveApi.getItems).mockResolvedValue({ items: [mockItem, mockItem2], total: 2 })
+      await useItemsStore.getState().fetchItems()
+
+      vi.mocked(troveApi.deleteItem).mockResolvedValue({ id: '01ABC' })
+
+      await useItemsStore.getState().deleteItem('01ABC')
+
+      expect(useItemsStore.getState().items).toEqual([mockItem2])
+      expect(useItemsStore.getState().total).toBe(1)
+    })
+
+    it('clears selectedItem if it was the deleted item', async () => {
+      vi.mocked(troveApi.getItem).mockResolvedValue(mockItem)
+      await useItemsStore.getState().fetchItem('01ABC')
+
+      vi.mocked(troveApi.deleteItem).mockResolvedValue({ id: '01ABC' })
+
+      await useItemsStore.getState().deleteItem('01ABC')
+
+      expect(useItemsStore.getState().selectedItem).toBeNull()
+    })
+
+    it('keeps selectedItem if a different item was deleted', async () => {
+      vi.mocked(troveApi.getItem).mockResolvedValue(mockItem2)
+      await useItemsStore.getState().fetchItem('01DEF')
+
+      vi.mocked(troveApi.getItems).mockResolvedValue({ items: [mockItem, mockItem2], total: 2 })
+      await useItemsStore.getState().fetchItems()
+
+      vi.mocked(troveApi.deleteItem).mockResolvedValue({ id: '01ABC' })
+
+      await useItemsStore.getState().deleteItem('01ABC')
+
+      expect(useItemsStore.getState().selectedItem).toEqual(mockItem2)
+    })
+  })
+})

--- a/src/renderer/src/stores/__tests__/media-types-store.test.ts
+++ b/src/renderer/src/stores/__tests__/media-types-store.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import type { MediaType } from '../../../../shared/types'
+import { useMediaTypesStore } from '../media-types-store'
+
+vi.mock('../../lib/trove-api')
+
+import * as troveApi from '../../lib/trove-api'
+
+const mockMediaTypes: MediaType[] = [
+  {
+    key: 'books',
+    label: 'Books',
+    icon: '📚',
+    color: '#4F7942',
+    fields_schema: [{ key: 'author', label: 'Author', type: 'text' }],
+    is_builtin: true,
+    sort_order: 0,
+  },
+  {
+    key: 'music',
+    label: 'Music',
+    icon: '🎵',
+    color: '#8B5CF6',
+    fields_schema: [{ key: 'artist', label: 'Artist', type: 'text' }],
+    is_builtin: true,
+    sort_order: 1,
+  },
+]
+
+describe('Media Types Store', () => {
+  beforeEach(() => {
+    useMediaTypesStore.getState()._reset()
+    vi.clearAllMocks()
+  })
+
+  describe('initial state', () => {
+    it('has correct defaults', () => {
+      const state = useMediaTypesStore.getState()
+      expect(state.mediaTypes).toEqual([])
+      expect(state.isLoading).toBe(false)
+      expect(state.error).toBeNull()
+    })
+  })
+
+  describe('fetchMediaTypes', () => {
+    it('fetches and stores media types', async () => {
+      vi.mocked(troveApi.getMediaTypes).mockResolvedValue(mockMediaTypes)
+
+      await useMediaTypesStore.getState().fetchMediaTypes()
+
+      const state = useMediaTypesStore.getState()
+      expect(state.mediaTypes).toEqual(mockMediaTypes)
+      expect(state.isLoading).toBe(false)
+      expect(state.error).toBeNull()
+    })
+
+    it('sets isLoading during fetch', async () => {
+      let resolvePromise: (value: MediaType[]) => void
+      vi.mocked(troveApi.getMediaTypes).mockImplementation(
+        () => new Promise((resolve) => (resolvePromise = resolve)),
+      )
+
+      const promise = useMediaTypesStore.getState().fetchMediaTypes()
+      expect(useMediaTypesStore.getState().isLoading).toBe(true)
+
+      resolvePromise!(mockMediaTypes)
+      await promise
+      expect(useMediaTypesStore.getState().isLoading).toBe(false)
+    })
+
+    it('handles errors', async () => {
+      vi.mocked(troveApi.getMediaTypes).mockRejectedValue(new Error('Network error'))
+
+      await useMediaTypesStore.getState().fetchMediaTypes()
+
+      const state = useMediaTypesStore.getState()
+      expect(state.error).toBe('Network error')
+      expect(state.isLoading).toBe(false)
+      expect(state.mediaTypes).toEqual([])
+    })
+  })
+
+  describe('getMediaType', () => {
+    it('returns the media type by key', async () => {
+      vi.mocked(troveApi.getMediaTypes).mockResolvedValue(mockMediaTypes)
+      await useMediaTypesStore.getState().fetchMediaTypes()
+
+      const result = useMediaTypesStore.getState().getMediaType('books')
+      expect(result).toEqual(mockMediaTypes[0])
+    })
+
+    it('returns undefined for missing key', async () => {
+      vi.mocked(troveApi.getMediaTypes).mockResolvedValue(mockMediaTypes)
+      await useMediaTypesStore.getState().fetchMediaTypes()
+
+      const result = useMediaTypesStore.getState().getMediaType('podcasts')
+      expect(result).toBeUndefined()
+    })
+  })
+})

--- a/src/renderer/src/stores/__tests__/subscriptions.test.ts
+++ b/src/renderer/src/stores/__tests__/subscriptions.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { useUIStore } from '../ui-store'
+import { useItemsStore } from '../items-store'
+import { setupStoreSubscriptions } from '../subscriptions'
+
+vi.mock('../../lib/trove-api')
+
+describe('Store Subscriptions', () => {
+  let unsubscribe: () => void
+
+  beforeEach(() => {
+    useUIStore.getState()._reset()
+    useItemsStore.getState()._reset()
+    vi.clearAllMocks()
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    unsubscribe?.()
+    vi.useRealTimers()
+  })
+
+  it('triggers fetchItems when activeTypeFilter changes', async () => {
+    const fetchItemsSpy = vi.spyOn(useItemsStore.getState(), 'fetchItems').mockResolvedValue()
+    unsubscribe = setupStoreSubscriptions()
+
+    useUIStore.getState().setActiveTypeFilter('books')
+    await vi.advanceTimersByTimeAsync(300)
+
+    expect(fetchItemsSpy).toHaveBeenCalled()
+  })
+
+  it('triggers fetchItems when searchQuery changes after debounce', async () => {
+    const fetchItemsSpy = vi.spyOn(useItemsStore.getState(), 'fetchItems').mockResolvedValue()
+    unsubscribe = setupStoreSubscriptions()
+
+    useUIStore.getState().setSearchQuery('tol')
+    useUIStore.getState().setSearchQuery('tolk')
+    useUIStore.getState().setSearchQuery('tolki')
+    useUIStore.getState().setSearchQuery('tolkien')
+
+    // Should not have fired yet (debounce)
+    expect(fetchItemsSpy).not.toHaveBeenCalled()
+
+    await vi.advanceTimersByTimeAsync(300)
+
+    // Should fire only once after debounce
+    expect(fetchItemsSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('triggers fetchItems when sortConfig changes', async () => {
+    const fetchItemsSpy = vi.spyOn(useItemsStore.getState(), 'fetchItems').mockResolvedValue()
+    unsubscribe = setupStoreSubscriptions()
+
+    useUIStore.getState().setSortConfig({ field: 'title', direction: 'asc' })
+    await vi.advanceTimersByTimeAsync(300)
+
+    expect(fetchItemsSpy).toHaveBeenCalled()
+  })
+
+  it('does not trigger fetchItems for unrelated state changes', async () => {
+    const fetchItemsSpy = vi.spyOn(useItemsStore.getState(), 'fetchItems').mockResolvedValue()
+    unsubscribe = setupStoreSubscriptions()
+
+    useUIStore.getState().setActiveView('list')
+    useUIStore.getState().toggleSidebar()
+    await vi.advanceTimersByTimeAsync(300)
+
+    expect(fetchItemsSpy).not.toHaveBeenCalled()
+  })
+
+  it('stops triggering after unsubscribe', async () => {
+    const fetchItemsSpy = vi.spyOn(useItemsStore.getState(), 'fetchItems').mockResolvedValue()
+    unsubscribe = setupStoreSubscriptions()
+    unsubscribe()
+
+    useUIStore.getState().setActiveTypeFilter('music')
+    await vi.advanceTimersByTimeAsync(300)
+
+    expect(fetchItemsSpy).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/stores/__tests__/ui-store.test.ts
+++ b/src/renderer/src/stores/__tests__/ui-store.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { useUIStore } from '../ui-store'
+
+describe('UI Store', () => {
+  beforeEach(() => {
+    useUIStore.getState()._reset()
+  })
+
+  describe('initial state', () => {
+    it('has correct defaults', () => {
+      const state = useUIStore.getState()
+      expect(state.activeView).toBe('grid')
+      expect(state.activeTypeFilter).toBeNull()
+      expect(state.searchQuery).toBe('')
+      expect(state.sortConfig).toEqual({ field: 'date_added', direction: 'desc' })
+      expect(state.sidebarCollapsed).toBe(false)
+    })
+  })
+
+  describe('setActiveView', () => {
+    it('updates the active view', () => {
+      useUIStore.getState().setActiveView('list')
+      expect(useUIStore.getState().activeView).toBe('list')
+
+      useUIStore.getState().setActiveView('table')
+      expect(useUIStore.getState().activeView).toBe('table')
+    })
+  })
+
+  describe('setActiveTypeFilter', () => {
+    it('sets a type filter', () => {
+      useUIStore.getState().setActiveTypeFilter('books')
+      expect(useUIStore.getState().activeTypeFilter).toBe('books')
+    })
+
+    it('clears the type filter with null', () => {
+      useUIStore.getState().setActiveTypeFilter('books')
+      useUIStore.getState().setActiveTypeFilter(null)
+      expect(useUIStore.getState().activeTypeFilter).toBeNull()
+    })
+  })
+
+  describe('setSearchQuery', () => {
+    it('updates the search query', () => {
+      useUIStore.getState().setSearchQuery('tolkien')
+      expect(useUIStore.getState().searchQuery).toBe('tolkien')
+    })
+  })
+
+  describe('setSortConfig', () => {
+    it('updates sort config', () => {
+      const config = { field: 'title', direction: 'asc' as const }
+      useUIStore.getState().setSortConfig(config)
+      expect(useUIStore.getState().sortConfig).toEqual(config)
+    })
+  })
+
+  describe('toggleSidebar', () => {
+    it('flips the collapsed state', () => {
+      expect(useUIStore.getState().sidebarCollapsed).toBe(false)
+      useUIStore.getState().toggleSidebar()
+      expect(useUIStore.getState().sidebarCollapsed).toBe(true)
+      useUIStore.getState().toggleSidebar()
+      expect(useUIStore.getState().sidebarCollapsed).toBe(false)
+    })
+  })
+
+  describe('_reset', () => {
+    it('restores all state to defaults', () => {
+      useUIStore.getState().setActiveView('table')
+      useUIStore.getState().setActiveTypeFilter('music')
+      useUIStore.getState().setSearchQuery('bach')
+      useUIStore.getState().setSortConfig({ field: 'title', direction: 'asc' })
+      useUIStore.getState().toggleSidebar()
+
+      useUIStore.getState()._reset()
+
+      const state = useUIStore.getState()
+      expect(state.activeView).toBe('grid')
+      expect(state.activeTypeFilter).toBeNull()
+      expect(state.searchQuery).toBe('')
+      expect(state.sortConfig).toEqual({ field: 'date_added', direction: 'desc' })
+      expect(state.sidebarCollapsed).toBe(false)
+    })
+  })
+})

--- a/src/renderer/src/stores/index.ts
+++ b/src/renderer/src/stores/index.ts
@@ -1,0 +1,4 @@
+export { useItemsStore } from './items-store'
+export { useMediaTypesStore } from './media-types-store'
+export { useUIStore } from './ui-store'
+export { setupStoreSubscriptions } from './subscriptions'

--- a/src/renderer/src/stores/items-store.ts
+++ b/src/renderer/src/stores/items-store.ts
@@ -1,0 +1,96 @@
+import { create } from 'zustand'
+import { devtools } from 'zustand/middleware'
+import type { Item, CreateItemInput, UpdateItemInput, ItemFilter } from '../../../shared/types'
+import * as troveApi from '../lib/trove-api'
+import { useUIStore } from './ui-store'
+
+interface ItemsState {
+  items: Item[]
+  total: number
+  selectedItem: Item | null
+  isLoading: boolean
+  error: string | null
+}
+
+interface ItemsActions {
+  fetchItems: () => Promise<void>
+  fetchItem: (id: string) => Promise<void>
+  createItem: (data: CreateItemInput) => Promise<Item>
+  updateItem: (id: string, data: UpdateItemInput) => Promise<Item>
+  deleteItem: (id: string) => Promise<void>
+  _reset: () => void
+}
+
+const initialState: ItemsState = {
+  items: [],
+  total: 0,
+  selectedItem: null,
+  isLoading: false,
+  error: null,
+}
+
+export const useItemsStore = create<ItemsState & ItemsActions>()(
+  devtools(
+    (set, get) => ({
+      ...initialState,
+
+      fetchItems: async () => {
+        set({ isLoading: true, error: null })
+        try {
+          const { activeTypeFilter, searchQuery, sortConfig } = useUIStore.getState()
+          const filter: ItemFilter = {
+            type: activeTypeFilter ?? undefined,
+            search: searchQuery || undefined,
+            sortBy: sortConfig.field,
+            sortDirection: sortConfig.direction,
+          }
+          const result = await troveApi.getItems(filter)
+          set({ items: result.items, total: result.total, isLoading: false })
+        } catch (err) {
+          set({
+            error: err instanceof Error ? err.message : 'Failed to fetch items',
+            isLoading: false,
+          })
+        }
+      },
+
+      fetchItem: async (id) => {
+        try {
+          const item = await troveApi.getItem(id)
+          set({ selectedItem: item })
+        } catch (err) {
+          set({
+            error: err instanceof Error ? err.message : 'Failed to fetch item',
+          })
+        }
+      },
+
+      createItem: async (data) => {
+        const item = await troveApi.createItem(data)
+        await get().fetchItems()
+        return item
+      },
+
+      updateItem: async (id, data) => {
+        const updated = await troveApi.updateItem(id, data)
+        set((state) => ({
+          items: state.items.map((item) => (item.id === id ? updated : item)),
+          selectedItem: state.selectedItem?.id === id ? updated : state.selectedItem,
+        }))
+        return updated
+      },
+
+      deleteItem: async (id) => {
+        await troveApi.deleteItem(id)
+        set((state) => ({
+          items: state.items.filter((item) => item.id !== id),
+          total: state.total - 1,
+          selectedItem: state.selectedItem?.id === id ? null : state.selectedItem,
+        }))
+      },
+
+      _reset: () => set(initialState),
+    }),
+    { name: 'ItemsStore' },
+  ),
+)

--- a/src/renderer/src/stores/media-types-store.ts
+++ b/src/renderer/src/stores/media-types-store.ts
@@ -1,0 +1,45 @@
+import { create } from 'zustand'
+import { devtools } from 'zustand/middleware'
+import type { MediaType } from '../../../shared/types'
+import * as troveApi from '../lib/trove-api'
+
+interface MediaTypesState {
+  mediaTypes: MediaType[]
+  isLoading: boolean
+  error: string | null
+}
+
+interface MediaTypesActions {
+  fetchMediaTypes: () => Promise<void>
+  getMediaType: (key: string) => MediaType | undefined
+  _reset: () => void
+}
+
+const initialState: MediaTypesState = {
+  mediaTypes: [],
+  isLoading: false,
+  error: null,
+}
+
+export const useMediaTypesStore = create<MediaTypesState & MediaTypesActions>()(
+  devtools(
+    (set, get) => ({
+      ...initialState,
+      fetchMediaTypes: async () => {
+        set({ isLoading: true, error: null })
+        try {
+          const mediaTypes = await troveApi.getMediaTypes()
+          set({ mediaTypes, isLoading: false })
+        } catch (err) {
+          set({
+            error: err instanceof Error ? err.message : 'Failed to fetch media types',
+            isLoading: false,
+          })
+        }
+      },
+      getMediaType: (key) => get().mediaTypes.find((mt) => mt.key === key),
+      _reset: () => set(initialState),
+    }),
+    { name: 'MediaTypesStore' },
+  ),
+)

--- a/src/renderer/src/stores/subscriptions.ts
+++ b/src/renderer/src/stores/subscriptions.ts
@@ -1,0 +1,27 @@
+import { shallow } from 'zustand/shallow'
+import { useUIStore } from './ui-store'
+import { useItemsStore } from './items-store'
+
+export function setupStoreSubscriptions(): () => void {
+  let debounceTimer: ReturnType<typeof setTimeout> | null = null
+
+  const unsubscribe = useUIStore.subscribe(
+    (state) => ({
+      activeTypeFilter: state.activeTypeFilter,
+      searchQuery: state.searchQuery,
+      sortConfig: state.sortConfig,
+    }),
+    () => {
+      if (debounceTimer) clearTimeout(debounceTimer)
+      debounceTimer = setTimeout(() => {
+        useItemsStore.getState().fetchItems()
+      }, 300)
+    },
+    { equalityFn: shallow },
+  )
+
+  return () => {
+    if (debounceTimer) clearTimeout(debounceTimer)
+    unsubscribe()
+  }
+}

--- a/src/renderer/src/stores/ui-store.ts
+++ b/src/renderer/src/stores/ui-store.ts
@@ -1,0 +1,47 @@
+import { create } from 'zustand'
+import { devtools, subscribeWithSelector } from 'zustand/middleware'
+
+export interface SortConfig {
+  field: string
+  direction: 'asc' | 'desc'
+}
+
+interface UIState {
+  activeView: 'grid' | 'list' | 'table'
+  activeTypeFilter: string | null
+  searchQuery: string
+  sortConfig: SortConfig
+  sidebarCollapsed: boolean
+}
+
+interface UIActions {
+  setActiveView: (view: UIState['activeView']) => void
+  setActiveTypeFilter: (type: string | null) => void
+  setSearchQuery: (query: string) => void
+  setSortConfig: (config: SortConfig) => void
+  toggleSidebar: () => void
+  _reset: () => void
+}
+
+const initialState: UIState = {
+  activeView: 'grid',
+  activeTypeFilter: null,
+  searchQuery: '',
+  sortConfig: { field: 'date_added', direction: 'desc' },
+  sidebarCollapsed: false,
+}
+
+export const useUIStore = create<UIState & UIActions>()(
+  devtools(
+    subscribeWithSelector((set) => ({
+      ...initialState,
+      setActiveView: (view) => set({ activeView: view }),
+      setActiveTypeFilter: (type) => set({ activeTypeFilter: type }),
+      setSearchQuery: (query) => set({ searchQuery: query }),
+      setSortConfig: (config) => set({ sortConfig: config }),
+      toggleSidebar: () => set((s) => ({ sidebarCollapsed: !s.sidebarCollapsed })),
+      _reset: () => set(initialState),
+    })),
+    { name: 'UIStore' },
+  ),
+)


### PR DESCRIPTION
Yes, all acceptance criteria are fulfilled. Let me verify each one against the implementation:

1. **Three Zustand stores created** — `ui-store.ts`, `media-types-store.ts`, `items-store.ts` under `src/renderer/src/stores/`

2. **Items store fetches through preload bridge IPC** — `items-store.ts` calls `troveApi.getItems()`, `getItem()`, `createItem()`, `updateItem()`, `deleteItem()` which go through `window.trove.invoke()` in `trove-api.ts`

3. **Changing active type filter triggers refetch** — Verified by test `subscriptions.test.ts`: `setActiveTypeFilter('books')` → debounce → `fetchItems()` called

4. **Changing search query triggers refetch** — Verified by test: rapid `setSearchQuery()` calls debounce to a single `fetchItems()` after 300ms

5. **Changing sort config triggers refetch** — Verified by test: `setSortConfig(...)` → debounce → `fetchItems()` called

6. **Loading and error states tracked and exposed** — `isLoading` and `error` on both items store and media types store, tested for fetch success, in-flight loading, and error cases

7. **All store hooks fully typed (TypeScript)** — `npm run typecheck` passes clean with strict mode. `useItemsStore`, `useMediaTypesStore`, `useUIStore` all have explicit state + action type parameters on `create<T>()`

8. **Stores consumable without providers** — Zustand's `create()` returns a hook that works anywhere. No `<Provider>` wrapping needed — confirmed by the store pattern used (vanilla Zustand, no context).